### PR TITLE
use debloated packages

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -33,6 +33,22 @@ jobs:
         pacman -U --noconfirm ./llvm-libs.pkg.tar.zst
         rm -f ./llvm-libs.pkg.tar.zst
 
+    - name: Install iculess libxml2 and qt6-core
+      run: |
+        QT6_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/qt6-base-iculess-x86_64.pkg.tar.zst"
+        LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-x86_64.pkg.tar.zst"
+        wget --retry-connrefused --tries=30 "$QT6_URL" -O ./qt6-base-iculess.pkg.tar.zst
+        wget --retry-connrefused --tries=30 "$LIBXML_URL" -O ./libxml2-iculess.pkg.tar.zst
+        pacman -U --noconfirm ./qt6-base-iculess.pkg.tar.zst ./libxml2-iculess.pkg.tar.zst
+        rm -f ./qt6-base-iculess.pkg.tar.zst ./libxml2-iculess.pkg.tar.zst
+
+    - name: Install ffmpeg mini
+      run: |
+        FFMPEG_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/ffmpeg-mini-x86_64.pkg.tar.zst"
+        wget --retry-connrefused --tries=30 "$FFMPEG_URL" -O ./ffmpeg-mini-x86_64.pkg.tar.zst
+        pacman -U --noconfirm ./ffmpeg-mini-x86_64.pkg.tar.zst
+        rm -f ./ffmpeg-mini-x86_64.pkg.tar.zst
+
     - name: Make AppImage
       run: |
         chmod +x ./*-appimage.sh && ./*-appimage.sh


### PR DESCRIPTION
For some reason a simple Qt app needs libLLVM and opengl?